### PR TITLE
Fix qspi dummy cycles

### DIFF
--- a/src/flash.rs
+++ b/src/flash.rs
@@ -100,7 +100,7 @@ impl Flash<'_> {
         let transaction: TransferConfig = TransferConfig {
             iwidth: QspiWidth::SING,
             awidth: QspiWidth::SING,
-            dwidth: QspiWidth::QUAD,
+            dwidth: QspiWidth::SING,
             instruction: 0x4B,
             address: Some(0x00),
             dummy: DummyCycles::_8,


### PR DESCRIPTION
Should resolve both #61 and #6 

* Removed the setting of QPI mode, and changed the other commands to suit.  This includes changing the write command from PP to PPQ so that the data is still sent in Quad mode.  This stops the Daisy Bootloader failing to load after a reset.
* Added a 'reset' step to the flash initiation, to restore the chip to a usable state
* Fixed the Dummy Cycles config step, and updated the read command to use 8 dummy cycles as per the datasheet. 