### PR TITLE
Fix audio input channel ordering for Patch SM

### DIFF
--- a/src/codec/pcm3060_i2c.rs
+++ b/src/codec/pcm3060_i2c.rs
@@ -64,7 +64,7 @@ impl<'a> Codec<'a> {
         sai_rx_config.stereo_mono = sai::StereoMono::Stereo;
         sai_rx_config.data_size = sai::DataSize::Data24;
         sai_rx_config.bit_order = sai::BitOrder::MsbFirst;
-        sai_rx_config.frame_sync_polarity = sai::FrameSyncPolarity::ActiveHigh;
+        sai_rx_config.frame_sync_polarity = sai::FrameSyncPolarity::ActiveLow;
         sai_rx_config.frame_sync_offset = sai::FrameSyncOffset::OnFirstBit;
         sai_rx_config.frame_length = 64;
         sai_rx_config.frame_sync_active_level_length = sai::word::U7(32);
@@ -78,6 +78,7 @@ impl<'a> Codec<'a> {
         sai_tx_config.tx_rx = sai::TxRx::Transmitter;
         sai_tx_config.sync_input = sai::SyncInput::Internal;
         sai_tx_config.clock_strobe = sai::ClockStrobe::Rising;
+        sai_rx_config.frame_sync_polarity = sai::FrameSyncPolarity::ActiveHigh;
         sai_tx_config.sync_output = false;
 
         let sai_tx = hal::sai::Sai::new_synchronous(


### PR DESCRIPTION
I noticed a while back that with the passthrough example on Patch SM, audio passed in through the left input channel was delivered out of the right output and vice versa.

Through experimentation I found the input order appeared to be wrong.

With this change, for every pair of samples in the input buffer, the first is from the left channel, and the 2nd is from the right.  The output buffer matches this.