### PR TITLE
Increase FMC speed to 166Mhz, add ADC clock config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,10 @@ pub fn default_rcc() -> hal::Config {
         divr: Some(PllDiv::DIV2),  // 480MHz TRACECLK
     });
     config.rcc.pll2 = Some(Pll {
-        source: PllSource::HSE,   // 16Mhz
-        prediv: PllPreDiv::DIV4,  // 4Mhz
-        mul: PllMul::MUL125,      // 500Mhz
+        source: PllSource::HSE,  // 16Mhz
+        prediv: PllPreDiv::DIV4, // 4Mhz
+        mul: PllMul::MUL125,     // 500Mhz
+        // Note: ADC uses this source by default, but the datasheet advises against using an odd numbered divider
         divp: Some(PllDiv::DIV5), // 100Mhz
         divq: None,
         divr: Some(PllDiv::DIV3), // 166Mhz for FMC (SDRAM)


### PR DESCRIPTION
## Summary
* Reconfigure pll2 so PLL2_R provides 166Mhz, increased from 100Mhz.
* Add a clock config for ADC to use - PLL3_R clocked at 98.33Mhz.
* Annotate the clock configuration with calculated speeds and usage.

## Motivation
### SDRAM
The SDRAM chip - `As4c16m32msa` can is rated to 166Mhz according to the datasheet. The FMC in the stm32 is ok up to 300Mhz.  Previously the configuration ran the interface at only 100Mhz.
My project uses the SDRAM fairly heavily, and I've noticed a significant performance improvement using this configuration.
### ADC
Since the ADC is so commonly used for CV inputs, I wanted to make sure there was still space for a good clock for it.  `PLL2_P` is the default, however to achieve 100Mhz there, a divider of 5 was necessary, and the datasheet states:
```
With a duty cycle close to 50%, meaning that DIV[P/Q/R]x values shall be even
```
It seemed to work ok when I tried it, but going against that advice feels like a bad idea, perhaps there would be strange issues down the line.

So instead I have used `PLL3_R`, at 98.33Mhz.