### PR TITLE
Remove default feature and require explicit board selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           components: clippy
           target: thumbv7em-none-eabihf
-      - run: cargo clippy --no-default-features --features seed -- --deny=warnings
-      - run: cargo clippy --no-default-features --features seed_1_1 -- --deny=warnings
-      - run: cargo clippy --no-default-features --features seed_1_2 -- --deny=warnings
-      - run: cargo clippy --no-default-features --features patch_sm -- --deny=warnings
+      - run: cargo clippy --features seed -- --deny=warnings
+      - run: cargo clippy --features seed_1_1 -- --deny=warnings
+      - run: cargo clippy --features seed_1_2 -- --deny=warnings
+      - run: cargo clippy --features patch_sm -- --deny=warnings

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,13 @@
     "[rust]": {
         "editor.formatOnSave": true
     },
+    "rust-analyzer.cargo.features": [
+        // Choose your board: uncomment exactly one of the following.
+        // Make sure your change here does NOT get committed😉
+        // "seed",
+        // "seed_1_1",
+        // "seed_1_2",
+        // "patch_sm",
+    ],
     "rust-analyzer.check.allTargets": false,
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,10 @@ This is a small, collaborative project maintained by a few developers. We aim to
 
 ```bash
   cargo fmt -- --check
-  cargo clippy --no-default-features --features seed -- --deny=warnings
-  cargo clippy --no-default-features --features seed_1_1 -- --deny=warnings
-  cargo clippy --no-default-features --features seed_1_2 -- --deny=warnings
-  cargo clippy --no-default-features --features patch_sm -- --deny=warnings
+  cargo clippy --features seed -- --deny=warnings
+  cargo clippy --features seed_1_1 -- --deny=warnings
+  cargo clippy --features seed_1_2 -- --deny=warnings
+  cargo clippy --features patch_sm -- --deny=warnings
 ```
 
 Please make sure your code passes these checks. If you're having trouble, feel free to mention it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,6 @@ heapless = { version = "0.8", default-features = false }
 micromath = "2.0.0"
 
 [features]
-default = ["seed_1_1"]
-
 seed = []
 seed_1_1 = []
 seed_1_2 = []

--- a/README.md
+++ b/README.md
@@ -96,25 +96,25 @@ See the `examples/` directory for more demos, such as `blinky.rs` or `triangle_w
    ```
 
 2. **Identify Your Board**:
-   - Daisy Seed (AK4556): Use `--features=seed --no-default-features`.
-   - Daisy Seed Rev5 (WM8731): Default, no extra flags.
-   - Daisy Seed Rev7 (PCM3060): Use `--features=seed_1_2 --no-default-features`.
-   - Daisy Patch SM: Use `--features=patch_sm --no-default-features`.
+   - Daisy Seed (AK4556): Use `--features=seed`.
+   - Daisy Seed Rev5 (WM8731): `--features=seed_1_1`.
+   - Daisy Seed Rev7 (PCM3060): Use `--features=seed_1_2`.
+   - Daisy Patch SM: Use `--features=patch_sm`.
 
 3. **Run an Example**:
 
    ```bash
-   # Rev4: Passthrough example
-   cargo run --example passthrough --features=seed --no-default-features --release
+   # Rev4(AK4556): Passthrough example
+   cargo run --example passthrough --features=seed --release
 
-   # Rev5: Blinky example
-   cargo run --example blinky --release
+   # Rev5(WM8731): Blinky example
+   cargo run --example blinky --features=seed_1_1 --release
 
-   # Rev7: Triangle wave example
-   cargo run --example triangle_wave_tx --features=seed_1_2 --no-default-features --release
+   # Rev7(PCM3060): Triangle wave example
+   cargo run --example triangle_wave_tx --features=seed_1_2 --release
 
    # Path SM: looper example
-   cargo run --example looper --features=patch_sm --no-default-features --release
+   cargo run --example looper --features=patch_sm --release
    ```
 
 4. **Build and Customize**:
@@ -122,6 +122,22 @@ See the `examples/` directory for more demos, such as `blinky.rs` or `triangle_w
    - Modify examples to create custom audio applications.
    - Debug issues using probe-rs logs.
    - When you find a bug, need help, or have suggestions, open an [Issue](https://github.com/daisy-embassy/daisy-embassy/issues).
+
+---
+
+## Development Setup
+
+### IDE Configuration
+
+This crate uses feature flags to gate board-specific code. When developing in an IDE, you must configure rust-analyzer to enable the appropriate feature flag for your board, otherwise you may encounter compilation errors.
+
+**For VS Code**: See `.vscode/settings.json` for an example configuration. Uncomment the feature flag corresponding to your board.
+
+**For Other Editors**: Refer to the VS Code settings as a template and configure your editor accordingly to enable the appropriate feature flag:
+- Daisy Seed (AK4556): `seed`
+- Daisy Seed Rev5 (WM8731): `seed_1_1`
+- Daisy Seed Rev7 (PCM3060): `seed_1_2`
+- Daisy Patch SM: `patch_sm`
 
 ---
 


### PR DESCRIPTION
### Background

Until now, this crate had a default feature enabled (`seed_1_1`).
This worked reasonably well when development was mostly done by a single maintainer(me) and the default board matched the primary development environment.

However, as the number of contributors and supported boards has grown, this implicit default has started to cause confusion and asymmetry:

* The active board was not always obvious from the build configuration
* Some board-specific code paths were unintentionally favored
* IDE setups (especially rust-analyzer) required implicit knowledge of the default feature

### What Changed

This PR removes the default feature entirely and requires **explicit board selection via feature flags**.

Concretely:

* The default feature has been removed from `Cargo.toml`
* CI and local checks now run `cargo clippy` without `--no-default-features`
* Documentation and examples have been updated to always specify `--features`
* A VS Code / rust-analyzer configuration example has been added to clarify local development setup

### Impact on Existing Users

This change may require users to explicitly specify a feature flag where the default previously worked implicitly.

For example:

```bash
cargo run --example blinky --features=seed_1_1
```

While this is a small behavioral change, it makes the target board explicit and avoids accidental mismatches.

### Rationale / Future Direction

The intent of this change is to make the project more **neutral, explicit, and scalable** as a collaborative codebase.

By requiring developers and users to consciously select their target board:

* All supported boards are treated equally
* Build and IDE behavior becomes more predictable

This PR is not meant to change functionality, but to clarify configuration and expectations as the project grows.
