### PR TITLE
faust.dsp with filter enabled, no meters, resolves daisy-embassy/daisy-embassy#72

### DIFF
--- a/examples/faust/simple-gain/Cargo.toml
+++ b/examples/faust/simple-gain/Cargo.toml
@@ -11,7 +11,11 @@ faust-traits = { git = "https://codeberg.org/crop/blech.git", rev = "1493f2f5da9
 faust-ui     = { git = "https://codeberg.org/crop/blech.git", rev = "1493f2f5da93ef0cbb2a05baf4bf281ad97674f6", default-features = false }
 
 cortex-m-rt   = { version = "0.7.0", features = ["device"] }
+
+# comment in the line that corresponds to your Daisy Seed revision
+# daisy-embassy = { path = "../../../../daisy-embassy", features = ["seed_1_2"], default-features = false }
 daisy-embassy = { path = "../../../../daisy-embassy", features = ["seed_1_1"] }
+
 defmt         = "1.0.1"
 libm          = "0.2.16"
 
@@ -47,7 +51,7 @@ embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "70aa
 embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "70aa65871e26f087e0baaf8e737371a4d5fd6d20" }
 embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "70aa65871e26f087e0baaf8e737371a4d5fd6d20" }
 embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "70aa65871e26f087e0baaf8e737371a4d5fd6d20" }
-embassy-usb = { git = "https://github.com/embassy-rs/embassy.git", rev = "70aa65871e26f087e0baaf8e737371a4d5fd6d20" }
+#embassy-usb = { git = "https://github.com/embassy-rs/embassy.git", rev = "70aa65871e26f087e0baaf8e737371a4d5fd6d20" }
 
 [profile.release]
 codegen-units = 1

--- a/examples/faust/simple-gain/README.md
+++ b/examples/faust/simple-gain/README.md
@@ -12,7 +12,9 @@
    ```bash
    touch ./src/dsp.rs
    ```
-4. Set the `FAUST_PATH` environment variable.
+4. Set the `FAUST_PATH` environment variable. If faust (>= 2.84.3) is installed and in your $PATH then modify build.rs according to the comment.
+
+5. If you are using a version 1.2 daisy seed, update the feature in Cargo.toml (there is a comment).
 
 Once you run `cargo run --release`, the files `./src/dsp.rs` and `./src/faust.dsp.json` will be automatically generated. These are auto-generated files produced by `faust-build` and `faust-ui-build`, based on `./src/faust.dsp`.
 

--- a/examples/faust/simple-gain/build.rs
+++ b/examples/faust/simple-gain/build.rs
@@ -17,9 +17,13 @@ fn main() {
     let mut b = file_with_ui("src/faust.dsp", "src/dsp.rs");
     b.set_code_option(CodeOption::NoFaustDsp);
     b.set_code_option(CodeOption::NoLibM);
+
+    // comment out these lines if faust is in your $PATH
+    // comment them in if you have the faust repo checked out and $FAUST_PATH set
     let faust_path = env::var("FAUST_PATH").expect("FAUST_PATH mut be set");
     b.set_faust_path(format!("{faust_path}/build/bin/faust"));
     b.set_import_dir(format!("{faust_path}/libraries/"));
+
     b.add_code_gen_fun(|_dsp_name| {
         quote::quote! {
             // use core::prelude::rust_2024::derive;
@@ -47,10 +51,10 @@ fn main() {
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
     println!("cargo:rerun-if-changed=memory.x");
-    
+
     // Re-run if FAUST_PATH environment variable changes
     println!("cargo:rerun-if-env-changed=FAUST_PATH");
-    
+
     // Re-run if the Faust DSP source file changes
     println!("cargo:rerun-if-changed=src/faust.dsp");
 }

--- a/examples/faust/simple-gain/src/faust.dsp
+++ b/examples/faust/simple-gain/src/faust.dsp
@@ -1,6 +1,17 @@
 declare name "LPVol";
 
 import("stdfaust.lib");
+fq = hslider("CutOff", 70, 0, 127, 1) : ba.midikey2hz; // removed control smoothing and visualizaion
+q = hslider("Resonance", 1, 0, 3, 0.001) : si.smoo;
+invol(i) = _ : _;  // pass through, removed VU meter
+outvol(i) = _ : _; // pass through, removed VU meter
 
-process = _,_  : par(i, 2, hgroup("1 controls", _ * (vslider("gain",0,-30,10,0.001):ba.db2linear: si.smoo)));
-
+process = _,_  : par(i, 2, hgroup("ClackFaust",
+									hgroup("0 in vol",invol(i)):
+									hgroup("1 controls",
+										vgroup("filter",
+                                        fi.svf.lp(fq, q))
+										*
+										(vslider("gain",0,-70,10,0.001):ba.db2linear: si.smoo))
+										<:
+									hgroup("2 out vol",outvol(i))));


### PR DESCRIPTION
This is a modified version of the faust.dsp file from https://github.com/daisy-embassy/daisy-embassy/issues/72
It is left as a draft for discussion, doc updates and resolving the build issue.

- The invol() and outvol() functions have been changed to no-op/pass-through because they were unneeded volume meters. This should be investigated in the future, and noted in the readme because it is commonly found in examples.
- I had to remove control smoothing from the frequency, not sure why.
- minor doc / script edits to help w/ v1.2 build and faust installed in $PATH checked out repo.

