### PR TITLE
Fix sample width mismatch in examples on Seed3 (#82)

### DIFF
--- a/examples/faust/simple-gain/src/main.rs
+++ b/examples/faust/simple-gain/src/main.rs
@@ -7,10 +7,10 @@
 
 #![no_std]
 #![no_main]
-use core::{array::from_fn, num::Wrapping};
+use core::array::from_fn;
 use daisy_embassy::{
     DaisyBoard,
-    audio::HALF_DMA_BUFFER_LENGTH,
+    audio::{HALF_DMA_BUFFER_LENGTH, f32_to_sample, sample_to_f32},
     hal::{self, bind_interrupts, exti::ExtiInput, gpio::Pull, interrupt, mode::Async},
     led::UserLed,
     new_daisy_board,
@@ -89,7 +89,7 @@ async fn main(spawner: Spawner) {
 }
 
 fn process_audio_faust(dsp: &mut dsp::LpVol, input: &[u32], output: &mut [u32]) {
-    let ibuf: [[f32; 64]; dsp::FAUST_INPUTS] = from_fn(|_| from_fn(|i| u24_to_f32(input[i])));
+    let ibuf: [[f32; 64]; dsp::FAUST_INPUTS] = from_fn(|_| from_fn(|i| sample_to_f32(input[i])));
     let mut obuf: [[f32; 64]; dsp::FAUST_OUTPUTS] = from_fn(|_| [0.0_f32; HALF_DMA_BUFFER_LENGTH]);
 
     // if a new value is recieved, set it.
@@ -101,22 +101,6 @@ fn process_audio_faust(dsp: &mut dsp::LpVol, input: &[u32], output: &mut [u32]) 
     dsp.compute(HALF_DMA_BUFFER_LENGTH, &ibuf, &mut obuf);
 
     for (i, f32_value) in obuf[0].iter().enumerate() {
-        output[i] = f32_to_u24(*f32_value);
+        output[i] = f32_to_sample(*f32_value);
     }
-}
-
-// see https://github.com/zlosynth/daisy
-// Convert audio PCM data from u24 to f32,
-#[inline(always)]
-fn u24_to_f32(y: u32) -> f32 {
-    let y = (Wrapping(y) + Wrapping(0x0080_0000)).0 & 0x00FF_FFFF; // convert to i32
-    (y as f32 / 8_388_608.0) - 1.0 // (2^24) / 2
-}
-
-// Convert audio data from f32 to u24 PCM
-#[inline(always)]
-fn f32_to_u24(x: f32) -> u32 {
-    let x = x * 8_388_607.0;
-    let x = x.clamp(-8_388_608.0, 8_388_607.0);
-    (x as i32) as u32
 }

--- a/examples/triangle_wave_tx.rs
+++ b/examples/triangle_wave_tx.rs
@@ -3,7 +3,10 @@
 
 use core::sync::atomic::{AtomicU8, Ordering};
 
-use daisy_embassy::{audio::HALF_DMA_BUFFER_LENGTH, hal, new_daisy_board};
+use daisy_embassy::{
+    audio::{HALF_DMA_BUFFER_LENGTH, f32_to_sample},
+    hal, new_daisy_board,
+};
 use defmt::{debug, unwrap};
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
@@ -103,7 +106,7 @@ async fn main(_spawner: Spawner) {
                 .start_callback(|_input, output| {
                     let period = WaveFrequency::from(wave_freq.load(Ordering::SeqCst)).as_period();
                     for chunk in buf.chunks_mut(2) {
-                        let smp = f32_to_u24(make_triangle_wave(smp_pos % period, period));
+                        let smp = f32_to_sample(make_triangle_wave(smp_pos % period, period));
                         if mute.is_high() {
                             chunk[0] = smp;
                             chunk[1] = smp;
@@ -131,13 +134,4 @@ fn make_triangle_wave(pos: u32, period_smp: u32) -> f32 {
         let pos = pos - period_smp / 2;
         pos as f32 * (-4.0) / period_smp as f32 + 1.0
     }
-}
-
-/// convert audio data from f32 to u24
-#[inline(always)]
-fn f32_to_u24(x: f32) -> u32 {
-    //return (int16_t) __SSAT((int32_t) (x * 32767.f), 16);
-    let x = x * 8_388_607.0;
-    let x = x.clamp(-8_388_608.0, 8_388_607.0);
-    (x as i32) as u32
 }

--- a/examples/usb_uac.rs
+++ b/examples/usb_uac.rs
@@ -4,7 +4,7 @@
 use core::cell::RefCell;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use daisy_embassy::audio::{Idle, Interface};
+use daisy_embassy::audio::{Idle, Interface, SAMPLE_WIDTH_BITS as CODEC_SAMPLE_WIDTH_BITS};
 use daisy_embassy::led::UserLed;
 use defmt::{panic, *};
 use embassy_executor::Spawner;
@@ -159,7 +159,8 @@ async fn audio_receiver_task(
                         led.on();
                         Default::default()
                     });
-                    *os = (sample >> 8) as u32;
+                    // Scale the 32-bit USB sample down to the codec's sample width.
+                    *os = (sample >> (32 - CODEC_SAMPLE_WIDTH_BITS)) as u32;
                 }
             })
             .await;

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -14,6 +14,31 @@ pub const BLOCK_LENGTH: usize = 32; // 32 samples
 pub const HALF_DMA_BUFFER_LENGTH: usize = BLOCK_LENGTH * 2; //  2 channels
 pub const DMA_BUFFER_LENGTH: usize = HALF_DMA_BUFFER_LENGTH * 2; //  2 half-blocks
 
+/// Number of significant bits in each 32-bit SAI word for the selected board's
+/// codec: 24 on Seed/Seed 1.1/Seed 1.2/Patch SM, 32 on Seed3 (TAC5242).
+pub use crate::codec::SAMPLE_WIDTH_BITS;
+
+/// Amplitude of a full-scale sample: `2^(SAMPLE_WIDTH_BITS - 1)`.
+const SAMPLE_SCALE: f32 = (1u32 << (SAMPLE_WIDTH_BITS - 1)) as f32;
+
+/// Convert an audio sample from f32 (`-1.0..1.0`) to the wire format expected
+/// by the selected board's codec.
+#[inline(always)]
+pub fn f32_to_sample(x: f32) -> u32 {
+    let x = x * SAMPLE_SCALE;
+    let x = x.clamp(-SAMPLE_SCALE, SAMPLE_SCALE - 1.0);
+    (x as i32) as u32
+}
+
+/// Convert an audio sample from the selected board's codec wire format to
+/// f32 (`-1.0..1.0`).
+#[inline(always)]
+pub fn sample_to_f32(y: u32) -> f32 {
+    // Sign-extend the SAMPLE_WIDTH_BITS-wide sample to i32 before normalizing.
+    const SHIFT: u32 = 32 - SAMPLE_WIDTH_BITS;
+    (((y << SHIFT) as i32) >> SHIFT) as f32 / SAMPLE_SCALE
+}
+
 // - static data --------------------------------------------------------------
 
 //DMA buffer must be in special region. Refer https://embassy.dev/book/#_stm32_bdma_only_working_out_of_some_ram_regions

--- a/src/codec/ak4556.rs
+++ b/src/codec/ak4556.rs
@@ -15,6 +15,12 @@ use hal::sai::{BitOrder, SyncInput};
 
 use hal::sai::{self, ClockStrobe, DataSize, FrameSyncPolarity, Mode, StereoMono, TxRx};
 
+/// Number of significant bits in each 32-bit SAI word.
+///
+/// The AK4556 transport is configured for 24-bit samples
+/// (`DataSize::Data24` below), so only the low 24 bits of each word are used.
+pub const SAMPLE_WIDTH_BITS: u32 = 24;
+
 pub struct Codec<'a> {
     reset: Output<'a>,
     sai_tx: sai::Sai<'a, peripherals::SAI1, u32>,

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,24 +1,24 @@
 #[cfg(feature = "seed")]
 mod ak4556;
 #[cfg(feature = "seed")]
-pub use ak4556::{Codec, Pins};
+pub use ak4556::{Codec, Pins, SAMPLE_WIDTH_BITS};
 
 #[cfg(feature = "seed_1_1")]
 mod wm8731;
 #[cfg(feature = "seed_1_1")]
-pub use wm8731::{Codec, Pins};
+pub use wm8731::{Codec, Pins, SAMPLE_WIDTH_BITS};
 
 #[cfg(feature = "seed_1_2")]
 mod pcm3060;
 #[cfg(feature = "seed_1_2")]
-pub use pcm3060::{Codec, Pins};
+pub use pcm3060::{Codec, Pins, SAMPLE_WIDTH_BITS};
 
 #[cfg(feature = "seed3")]
 mod tac5242;
 #[cfg(feature = "seed3")]
-pub use tac5242::{Codec, Pins};
+pub use tac5242::{Codec, Pins, SAMPLE_WIDTH_BITS};
 
 #[cfg(feature = "patch_sm")]
 mod pcm3060_i2c;
 #[cfg(feature = "patch_sm")]
-pub use pcm3060_i2c::{Codec, Pins};
+pub use pcm3060_i2c::{Codec, Pins, SAMPLE_WIDTH_BITS};

--- a/src/codec/pcm3060.rs
+++ b/src/codec/pcm3060.rs
@@ -3,6 +3,12 @@ use defmt::info;
 use embassy_stm32::{self as hal, Peri, peripherals, sai};
 use hal::peripherals::*;
 
+/// Number of significant bits in each 32-bit SAI word.
+///
+/// The PCM3060 transport is configured for 24-bit samples
+/// (`sai::DataSize::Data24` below), so only the low 24 bits of each word are used.
+pub const SAMPLE_WIDTH_BITS: u32 = 24;
+
 /// Codec and Pins for the PCM3060 audio codec configured by hardware (not using i2c)
 pub struct Codec<'a> {
     sai_tx: sai::Sai<'a, peripherals::SAI1, u32>,

--- a/src/codec/pcm3060_i2c.rs
+++ b/src/codec/pcm3060_i2c.rs
@@ -24,6 +24,12 @@ const ADC_PSV_MASK: u8 = 0x20;
 const DAC_PSV_MASK: u8 = 0x10;
 const FMT_MASK: u8 = 0x1;
 
+/// Number of significant bits in each 32-bit SAI word.
+///
+/// The PCM3060 transport is configured for 24-bit samples
+/// (`sai::DataSize::Data24` below), so only the low 24 bits of each word are used.
+pub const SAMPLE_WIDTH_BITS: u32 = 24;
+
 pub struct Codec<'a> {
     i2c: hal::i2c::I2c<'a, hal::mode::Blocking, hal::i2c::Master>,
     sai_tx: sai::Sai<'a, peripherals::SAI1, u32>,

--- a/src/codec/tac5242.rs
+++ b/src/codec/tac5242.rs
@@ -14,6 +14,12 @@ use hal::peripherals::*;
 /// reinitialization deterministic.
 const STARTUP_DELAY_MS: u64 = 2;
 
+/// Number of significant bits in each 32-bit SAI word.
+///
+/// The TAC5242 transport is configured for full 32-bit samples
+/// (`sai::DataSize::Data32` below), so samples must fill the whole word.
+pub const SAMPLE_WIDTH_BITS: u32 = 32;
+
 /// Audio codec transport for the hardware-strapped TAC5242 on Seed3.
 pub struct Codec<'a> {
     sai_tx: sai::Sai<'a, peripherals::SAI1, u32>,

--- a/src/codec/wm8731.rs
+++ b/src/codec/wm8731.rs
@@ -15,6 +15,12 @@ use crate::audio::{AudioConfig, AudioIrqs, AudioPeripherals, Fs};
 
 const I2C_FS: Hertz = Hertz(100_000);
 
+/// Number of significant bits in each 32-bit SAI word.
+///
+/// The WM8731 transport is configured for 24-bit samples
+/// (`DataSize::Data24` below), so only the low 24 bits of each word are used.
+pub const SAMPLE_WIDTH_BITS: u32 = 24;
+
 /// A simple HAL for the Cirrus Logic/ Wolfson WM8731 audio codec
 pub struct Codec<'a> {
     i2c: hal::i2c::I2c<'a, hal::mode::Blocking, hal::i2c::Master>,


### PR DESCRIPTION
Seed3's TAC5242 transport uses 32-bit SAI words, but the examples hardcoded 24-bit sample scaling, leaving the top 8 bits of each word clear and the output ~48 dB below full scale.

Closes #82 